### PR TITLE
Problem: elasticsearch 2.x does not accept periods in JSON fields

### DIFF
--- a/captainslog.go
+++ b/captainslog.go
@@ -1,0 +1,13 @@
+package captainslog
+
+import "errors"
+
+var (
+	// ErrMutate is returned by a Mutator when it cannot
+	// perform its function
+	ErrMutate = errors.New("mutate error")
+)
+
+type Mutator interface {
+	Mutate(string) (string, error)
+}

--- a/jsonforelastic.go
+++ b/jsonforelastic.go
@@ -1,0 +1,38 @@
+package captainslog
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+type JSONForElasticMutator struct{}
+
+func (m *JSONForElasticMutator) Mutate(msg *SyslogMsg) error {
+	if !msg.Cee {
+		return ErrMutate
+	}
+
+	var contentStructured map[string]interface{}
+
+	var err error
+
+	err = json.Unmarshal([]byte(msg.Content), &contentStructured)
+	if err != nil {
+		return err
+	}
+
+	mutatedStructured := make(map[string]interface{})
+	for k, v := range contentStructured {
+		k = strings.Replace(k, ".", "_", -1)
+		mutatedStructured[k] = v
+	}
+
+	newContent, err := json.Marshal(mutatedStructured)
+	if err != nil {
+		return err
+	}
+
+	msg.Content = fmt.Sprintf("%s%s\n", "@cee:", string(newContent))
+	return err
+}

--- a/jsonforelastic_test.go
+++ b/jsonforelastic_test.go
@@ -1,0 +1,63 @@
+package captainslog
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestJSONForElasticMutatorMutate(t *testing.T) {
+	b := []byte("<191>2006-01-02T15:04:05.999999-07:00 host.example.org test: @cee:{\"first.name\":\"captain\"}\n")
+
+	var msg SyslogMsg
+	err := Unmarshal(b, &msg)
+	if err != nil {
+		t.Error(err)
+	}
+
+	mutator := &JSONForElasticMutator{}
+	err = mutator.Mutate(&msg)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if want, got := "@cee:{\"first_name\":\"captain\"}\n", msg.Content; want != got {
+		t.Errorf("want '%s', got '%s'", want, got)
+	}
+}
+
+func ExampleJSONForElasticMutatorMutate() {
+	b := []byte("<191>2006-01-02T15:04:05.999999-07:00 host.example.org test: @cee:{\"first.name\":\"captain\"}\n")
+
+	var msg SyslogMsg
+	err := Unmarshal(b, &msg)
+	if err != nil {
+		panic(err)
+	}
+
+	mutator := &JSONForElasticMutator{}
+	err = mutator.Mutate(&msg)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf(msg.Content)
+	// Output: @cee:{"first_name":"captain"}
+}
+
+func BenchmarkJSONForElasticMutatorMutate(b *testing.B) {
+	m := []byte("<191>2006-01-02T15:04:05.999999-07:00 host.example.org test: @cee:{\"first.name\":\"captain\"}\n")
+	mutator := &JSONForElasticMutator{}
+
+	for i := 0; i < b.N; i++ {
+		var msg SyslogMsg
+		err := Unmarshal(m, &msg)
+		if err != nil {
+			panic(err)
+		}
+
+		err = mutator.Mutate(&msg)
+		if err != nil {
+			panic(err)
+		}
+	}
+}


### PR DESCRIPTION
Solution:
* Add a "mutator" interface that can be implemented for functions that wish to transform syslog messages.
* Implement a mutator that accepts rfc3164 @cee logs, scans their keys and changes all "." to "_".