### PR TITLE
Problem: mutator should return mutated copy

### DIFF
--- a/captainslog.go
+++ b/captainslog.go
@@ -9,5 +9,5 @@ var (
 )
 
 type Mutator interface {
-	Mutate(string) (string, error)
+	Mutate(SyslogMsg) (SyslogMsg, error)
 }

--- a/jsonforelastic.go
+++ b/jsonforelastic.go
@@ -2,24 +2,22 @@ package captainslog
 
 import (
 	"encoding/json"
-	"fmt"
 	"strings"
 )
 
 type JSONForElasticMutator struct{}
 
-func (m *JSONForElasticMutator) Mutate(msg *SyslogMsg) error {
+func (m *JSONForElasticMutator) Mutate(msg SyslogMsg) (SyslogMsg, error) {
 	if !msg.Cee {
-		return ErrMutate
+		return msg, ErrMutate
 	}
 
 	var contentStructured map[string]interface{}
-
 	var err error
 
 	err = json.Unmarshal([]byte(msg.Content), &contentStructured)
 	if err != nil {
-		return err
+		return msg, err
 	}
 
 	mutatedStructured := make(map[string]interface{})
@@ -30,9 +28,10 @@ func (m *JSONForElasticMutator) Mutate(msg *SyslogMsg) error {
 
 	newContent, err := json.Marshal(mutatedStructured)
 	if err != nil {
-		return err
+		return msg, err
 	}
 
-	msg.Content = fmt.Sprintf("%s%s\n", "@cee:", string(newContent))
-	return err
+	mutated := msg
+	mutated.Content = string(newContent)
+	return mutated, err
 }

--- a/jsonforelastic_test.go
+++ b/jsonforelastic_test.go
@@ -5,22 +5,31 @@ import (
 	"testing"
 )
 
-func TestJSONForElasticMutatorMutate(t *testing.T) {
-	b := []byte("<191>2006-01-02T15:04:05.999999-07:00 host.example.org test: @cee:{\"first.name\":\"captain\"}\n")
+func checkMutateInterface(m Mutator) {
+	return
+}
 
-	var msg SyslogMsg
-	err := Unmarshal(b, &msg)
+func TestJSONForElastcMutatorIsMutator(t *testing.T) {
+	mutator := &JSONForElasticMutator{}
+	checkMutateInterface(mutator)
+}
+
+func TestJSONForElasticMutatorMutate(t *testing.T) {
+	b := []byte("<191>2006-01-02T15:04:05.999999-07:00 host.example.org test: @cee:{\"first.name\":\"captain\",\"one.two.three\":\"four.five.six\"}\n")
+
+	var original SyslogMsg
+	err := Unmarshal(b, &original)
 	if err != nil {
 		t.Error(err)
 	}
 
 	mutator := &JSONForElasticMutator{}
-	err = mutator.Mutate(&msg)
+	mutated, err := mutator.Mutate(original)
 	if err != nil {
 		t.Error(err)
 	}
 
-	if want, got := "@cee:{\"first_name\":\"captain\"}\n", msg.Content; want != got {
+	if want, got := "{\"first_name\":\"captain\",\"one_two_three\":\"four.five.six\"}", mutated.Content; want != got {
 		t.Errorf("want '%s', got '%s'", want, got)
 	}
 }
@@ -28,20 +37,20 @@ func TestJSONForElasticMutatorMutate(t *testing.T) {
 func ExampleJSONForElasticMutatorMutate() {
 	b := []byte("<191>2006-01-02T15:04:05.999999-07:00 host.example.org test: @cee:{\"first.name\":\"captain\"}\n")
 
-	var msg SyslogMsg
-	err := Unmarshal(b, &msg)
+	var original SyslogMsg
+	err := Unmarshal(b, &original)
 	if err != nil {
 		panic(err)
 	}
 
 	mutator := &JSONForElasticMutator{}
-	err = mutator.Mutate(&msg)
+	mutated, err := mutator.Mutate(original)
 	if err != nil {
 		panic(err)
 	}
 
-	fmt.Printf(msg.Content)
-	// Output: @cee:{"first_name":"captain"}
+	fmt.Printf(mutated.Content)
+	// Output: {"first_name":"captain"}
 }
 
 func BenchmarkJSONForElasticMutatorMutate(b *testing.B) {
@@ -49,13 +58,13 @@ func BenchmarkJSONForElasticMutatorMutate(b *testing.B) {
 	mutator := &JSONForElasticMutator{}
 
 	for i := 0; i < b.N; i++ {
-		var msg SyslogMsg
-		err := Unmarshal(m, &msg)
+		var original SyslogMsg
+		err := Unmarshal(m, &original)
 		if err != nil {
 			panic(err)
 		}
 
-		err = mutator.Mutate(&msg)
+		_, err = mutator.Mutate(original)
 		if err != nil {
 			panic(err)
 		}

--- a/rfc3164.go
+++ b/rfc3164.go
@@ -166,6 +166,7 @@ type parser struct {
 // and a pointer to a SyslogMsg struct, and attempts to parse
 // the message and fill in the struct.
 func Unmarshal(b []byte, msg *SyslogMsg) error {
+
 	p := &parser{
 		buf:    b,
 		bufLen: len(b),


### PR DESCRIPTION
Solution: change Mutator to return a copy of the original SyslogMsg instead of mutating the message in place.  In benchmarks, this actually turns out to be slightly faster than mutating the message in place, and it eliminates some complexity and potential errors when using this interface.

