### PR TITLE
Problem: cee parse impl. made reproducing log from struct difficult

### DIFF
--- a/jsonforelastic.go
+++ b/jsonforelastic.go
@@ -8,7 +8,7 @@ import (
 type JSONForElasticMutator struct{}
 
 func (m *JSONForElasticMutator) Mutate(msg SyslogMsg) (SyslogMsg, error) {
-	if !msg.Cee {
+	if !msg.IsCee {
 		return msg, ErrMutate
 	}
 

--- a/rfc3164_test.go
+++ b/rfc3164_test.go
@@ -64,7 +64,7 @@ func TestNewLog(t *testing.T) {
 	}
 
 	// cee
-	if want, got := false, msg.Cee; want != got {
+	if want, got := false, msg.IsCee; want != got {
 		t.Errorf("want '%v', got '%v'", want, got)
 	}
 
@@ -83,8 +83,12 @@ func TestNewLogCeeSpace(t *testing.T) {
 		t.Error(err)
 	}
 
-	if want, got := true, msg.Cee; want != got {
+	if want, got := true, msg.IsCee; want != got {
 		t.Errorf("want '%v', got '%v'", want, got)
+	}
+
+	if want, got := " @cee", msg.Cee; want != got {
+		t.Errorf("want '%s', got '%s'", want, got)
 	}
 
 	if want, got := "{\"a\":\"b\"}", msg.Content; want != got {
@@ -100,8 +104,12 @@ func TestNewLogCeeNoSpace(t *testing.T) {
 		t.Error(err)
 	}
 
-	if want, got := true, msg.Cee; want != got {
+	if want, got := true, msg.IsCee; want != got {
 		t.Errorf("want '%v', got '%v'", want, got)
+	}
+
+	if want, got := "@cee", msg.Cee; want != got {
+		t.Errorf("want '%s', got '%s'", want, got)
 	}
 }
 


### PR DESCRIPTION
Solution: Change the parser to save the @cee content as found as part of the syslog message.  This PR additionally collapses some "start / end" fields into the parser into tokenStart / tokenEnd as the specific fields were not needed.