### PR TITLE
Problem: I want a service that can fix json keys for elasticsearch

### DIFF
--- a/captainslog.go
+++ b/captainslog.go
@@ -8,6 +8,7 @@ var (
 	ErrMutate = errors.New("mutate error")
 )
 
+// Mutators accept a SyslogMsg, and return a modified SyslogMsg
 type Mutator interface {
 	Mutate(SyslogMsg) (SyslogMsg, error)
 }

--- a/cmd/elauneind/main.go
+++ b/cmd/elauneind/main.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"bufio"
+	"flag"
+	"io"
+	"log"
+	"net"
+	"os"
+	"time"
+
+	"github.com/digitalocean/captainslog"
+)
+
+const (
+	retryInterval = 5
+)
+
+func main() {
+	var recvAddress = flag.String("in", ":33333", "TCP endpoint to receive from")
+	var sendAddress = flag.String("out", "127.0.0.1:514", "TCP endpoint to send to")
+
+	flag.Parse()
+
+	sendChan := make(chan *captainslog.SyslogMsg)
+
+	go func() {
+	Connect:
+		conn, err := net.Dial("tcp", *sendAddress)
+		if err != nil {
+			log.Printf("E: connect error - %s", err)
+			time.Sleep(time.Duration(retryInterval) * time.Second)
+			goto Connect
+		}
+		defer conn.Close()
+
+		for msg := range sendChan {
+			_, err := conn.Write(msg.Bytes())
+			if err != nil {
+				log.Printf("E: write error - %s", err)
+				time.Sleep(time.Duration(retryInterval) * time.Second)
+				goto Connect
+			}
+		}
+	}()
+
+	l, err := net.Listen("tcp", *recvAddress)
+	if err != nil {
+		log.Printf("E: listen error - %s", err)
+		os.Exit(1)
+	}
+	defer l.Close()
+
+	for {
+		conn, err := l.Accept()
+		if err != nil {
+			log.Printf("E: accept error - %s", err)
+			continue
+		}
+		defer conn.Close()
+
+		go func() {
+			reader := bufio.NewReader(conn)
+			mutator := &captainslog.JSONForElasticMutator{}
+
+			for {
+				b, err := reader.ReadBytes('\n')
+				if err != nil {
+					if err != io.EOF {
+						log.Printf("E: readbytes error - %s", err)
+					}
+					break
+				}
+
+				var original captainslog.SyslogMsg
+				err = captainslog.Unmarshal(b, &original)
+				if err != nil {
+					log.Printf("E: unmarshal error - %s", err)
+					log.Print(err)
+					continue
+				}
+
+				mutated, err := mutator.Mutate(original)
+				if err != nil {
+					log.Printf("E: mutate error - %s", err)
+					continue
+				}
+
+				sendChan <- &mutated
+			}
+		}()
+	}
+}

--- a/rfc3164.go
+++ b/rfc3164.go
@@ -153,6 +153,11 @@ func (s *SyslogMsg) String() string {
 	return fmt.Sprintf("<%d>%s %s %s%s%s\n", s.Pri.Priority, s.Time.Format(s.timeFormat), s.Host, s.Tag, s.Cee, s.Content)
 }
 
+// Bytes returns the SyslogMsg as RFC3164 []byte
+func (s *SyslogMsg) Bytes() []byte {
+	return []byte(s.String())
+}
+
 type parser struct {
 	tokenStart int
 	tokenEnd   int

--- a/rfc3164_test.go
+++ b/rfc3164_test.go
@@ -427,3 +427,44 @@ func BenchmarkParserParse(b *testing.B) {
 		}
 	}
 }
+
+func BenchmarkParserParseLeastLikelyTime(b *testing.B) {
+	m := []byte("<38>Mon Jan  2 15:04:05 host.example.org test: hello world\n")
+
+	var msg SyslogMsg
+
+	for i := 0; i < b.N; i++ {
+		err := Unmarshal(m, &msg)
+		if err != nil {
+			panic(err)
+		}
+	}
+}
+
+func BenchmarkParserParseAndString(b *testing.B) {
+	m := []byte("<191>2006-01-02T15:04:05.999999-07:00 host.example.org test: hello world\n")
+
+	var msg SyslogMsg
+
+	for i := 0; i < b.N; i++ {
+		err := Unmarshal(m, &msg)
+		if err != nil {
+			panic(err)
+		}
+		_ = msg.String()
+	}
+}
+
+func BenchmarkParserParseAndBytes(b *testing.B) {
+	m := []byte("<191>2006-01-02T15:04:05.999999-07:00 host.example.org test: hello world\n")
+
+	var msg SyslogMsg
+
+	for i := 0; i < b.N; i++ {
+		err := Unmarshal(m, &msg)
+		if err != nil {
+			panic(err)
+		}
+		_ = msg.Bytes()
+	}
+}


### PR DESCRIPTION
Solution: Add a minimal service that listens on TCP, parses incoming rfc3164 messages, extracts the JSON body (if found) and changes "."'s in JSON field names into something elasticsearch 2.x will accept.