### PR TITLE
Problem: we would like an output plugin interface

### DIFF
--- a/output_gadget.go
+++ b/output_gadget.go
@@ -1,0 +1,11 @@
+package captainslog
+
+// OutputGadget is an interface for Output Gadgets.
+// Output Gadgets plug in to an OutputGizmo to provide
+// its functionality.
+type OutputGadget interface {
+	Output(s *SyslogMsg) (int, error)
+	Connect() error
+	RetryInterval() int
+	Close()
+}

--- a/output_gadget_tcp.go
+++ b/output_gadget_tcp.go
@@ -1,0 +1,43 @@
+package captainslog
+
+import "net"
+
+// OutputGadgetTCP is a gadget for
+// sending syslog messages over TCP
+type OutputGadgetTCP struct {
+	conn          net.Conn
+	address       string
+	retryInterval int
+}
+
+// NewOutputGadgetTCP accepts an address and a retry interval
+// and returns a new running gadget
+func NewOutputGadgetTCP(address string, retry int) *OutputGadgetTCP {
+	return &OutputGadgetTCP{
+		address:       address,
+		retryInterval: retry,
+	}
+}
+
+// Connect tries to connect the gadget to an address
+func (o *OutputGadgetTCP) Connect() error {
+	var err error
+	o.conn, err = net.Dial("tcp", o.address)
+	return err
+}
+
+// Output accepts a SyslogMsg pointer and sends an RFC3164
+// []byte representation of it over TCP
+func (o *OutputGadgetTCP) Output(s *SyslogMsg) (int, error) {
+	return o.conn.Write(s.Bytes())
+}
+
+// RetryInterval returns the retry interval of the gadget
+func (o *OutputGadgetTCP) RetryInterval() int {
+	return o.retryInterval
+}
+
+// Close closes the underlying connection in the gadget
+func (o *OutputGadgetTCP) Close() {
+	o.conn.Close()
+}

--- a/output_gizmo.go
+++ b/output_gizmo.go
@@ -1,0 +1,70 @@
+package captainslog
+
+import (
+	"log"
+	"time"
+)
+
+// Command represents a command that can
+// be sent to a Gizmo
+type Command int
+
+const (
+	// CmdStop tells a Gizmo to stop
+	CmdStop Command = iota
+)
+
+// OutputGizmo is an output that forwards
+// syslog messages to another destination
+type OutputGizmo struct {
+	CmdChan chan<- Command
+	OutChan chan<- *SyslogMsg
+	gadget  OutputGadget
+}
+
+// NewOutputGizmo accepts an OutputGadget and returns
+// an new OutputGizmo that uses that OutputGadget
+func NewOutputGizmo(g OutputGadget) *OutputGizmo {
+	cmdChan := make(chan Command)
+	outChan := make(chan *SyslogMsg)
+
+	o := &OutputGizmo{
+		CmdChan: cmdChan,
+		OutChan: outChan,
+		gadget:  g,
+	}
+
+	go o.actor(cmdChan, outChan)
+
+	return o
+}
+
+func (o *OutputGizmo) actor(cmdChan <-chan Command, outChan <-chan *SyslogMsg) {
+Connect:
+	err := o.gadget.Connect()
+	if err != nil {
+		log.Print("could not connect")
+		time.Sleep(time.Duration(o.gadget.RetryInterval()) * time.Second)
+		goto Connect
+	}
+
+	for {
+		select {
+		case cmd := <-cmdChan:
+			switch cmd {
+			case CmdStop:
+				goto Stop
+			}
+		case msg := <-outChan:
+			_, err := o.gadget.Output(msg)
+			if err != nil {
+				log.Print("could not send message")
+				goto Connect
+			}
+		}
+	}
+Stop:
+	o.gadget.Close()
+	close(o.CmdChan)
+	close(o.OutChan)
+}

--- a/output_gizmo_test.go
+++ b/output_gizmo_test.go
@@ -1,0 +1,57 @@
+package captainslog
+
+import (
+	"bufio"
+	"bytes"
+	"net"
+	"sync"
+	"testing"
+)
+
+func TestOutputGizmoWithTCPOutputPlugin(t *testing.T) {
+	testMsg := []byte("<191>2006-01-02T15:04:05.999999-07:00 host.example.org test: hello world\n")
+	var msg SyslogMsg
+	err := Unmarshal(testMsg, &msg)
+	if err != nil {
+		t.Error(err)
+	}
+
+	address := "127.0.0.1:45454"
+	retryInterval := 5
+
+	l, err := net.Listen("tcp", address)
+	if err != nil {
+		t.Error(err)
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	go func() {
+		conn, err := l.Accept()
+		if err != nil {
+			t.Error(err)
+		}
+
+		reader := bufio.NewReader(conn)
+		line, _, err := reader.ReadLine()
+		if err != nil {
+			t.Error(err)
+		}
+
+		line = append(line, '\n')
+		if want, got := 0, bytes.Compare(testMsg, line); want != got {
+			t.Errorf("want '%v', got '%v'", want, got)
+			t.Errorf("%s", line)
+		}
+
+		wg.Done()
+	}()
+
+	op := NewOutputGadgetTCP(address, retryInterval)
+	o := NewOutputGizmo(op)
+
+	o.OutChan <- &msg
+	o.CmdChan <- CmdStop
+	wg.Wait()
+}


### PR DESCRIPTION
This PR adds:

* OutputGizmo - "gizmos" are single units of functionality for doing things like receiving messages, sending messages, and modifying messages.
* OutputGadget - an interface for creating output gadgets - gadgets plug in to gizmos to provide functionality for the gizmo

This PR also modifies elauneind (our example and test service) to use an OutputGizmo with the TCP output gadget to forward syslog messages over TCP.