### PR TITLE
Problem: we want to encapsulate the tagging logic into an interface

### DIFF
--- a/captainslog.go
+++ b/captainslog.go
@@ -13,6 +13,11 @@ type Transformer interface {
 	Transform(SyslogMsg) (SyslogMsg, error)
 }
 
+// Mutator accepts a pointer to a SyslogMsg and modifies it in place
+type Mutator interface {
+	Mutate(*SyslogMsg) error
+}
+
 // Matcher accepts a SyslogMsg and returns true if it matches
 type Matcher interface {
 	Match(msg *SyslogMsg) bool

--- a/tagrangetransformer_test.go
+++ b/tagrangetransformer_test.go
@@ -42,7 +42,8 @@ func TestTagRangeTransformerTransform(t *testing.T) {
 		NewTagMatcher("kernel:"),
 		NewContentContainsMatcher("[ cut here ]"),
 		NewContentContainsMatcher("[ end trace"),
-		"tags", "trace", 60, 30)
+		NewTagArrayMutator("tags", "trace"),
+		60, 30)
 
 	for i, v := range cases {
 		original := NewSyslogMsg()
@@ -71,7 +72,8 @@ func BenchmarkTagRangeTransformerTransform(b *testing.B) {
 		NewTagMatcher("kernel:"),
 		NewContentContainsMatcher("[ cut here ]"),
 		NewContentContainsMatcher("[ end trace"),
-		"tags", "trace", 60, 30)
+		NewTagArrayMutator("tags", "trace"),
+		60, 30)
 
 	for i := 0; i < b.N; i++ {
 		original := NewSyslogMsg()


### PR DESCRIPTION
Solution: add a new Mutator interface for mutating a *SyslogMsg, and TagArrayMutator, which is an implementation of Mutator that adds tag to a tag array.