### PR TITLE
Problem: SyslogMsg.String() should include tags added after parse

### DIFF
--- a/syslogmsg.go
+++ b/syslogmsg.go
@@ -3,6 +3,7 @@ package captainslog
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 )
 
@@ -36,7 +37,18 @@ func (s *SyslogMsg) String() string {
 		}
 		content = string(b)
 	} else {
-		content = s.Content
+		if len(s.JSONValues) > 0 {
+			s.JSONValues["msg"] = strings.TrimLeft(s.Content, " ")
+			s.IsCee = true
+			s.Cee = " @cee:"
+			b, err := json.Marshal(s.JSONValues)
+			if err != nil {
+				panic(err)
+			}
+			content = string(b)
+		} else {
+			content = s.Content
+		}
 	}
 	return fmt.Sprintf("<%d>%s %s %s%s%s\n", s.Pri.Priority, s.Time.Format(s.timeFormat), s.Host, s.Tag, s.Cee, content)
 }

--- a/syslogmsg_test.go
+++ b/syslogmsg_test.go
@@ -1,0 +1,28 @@
+package captainslog
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSyslogMsgPlainWithAddedKeys(t *testing.T) {
+	input := []byte("<4>2016-03-08T14:59:36.293816+00:00 host.example.com kernel: [15803005.789011] ------------[ cut here ]------------\n")
+
+	msg := NewSyslogMsg()
+	err := Unmarshal(input, &msg)
+	if err != nil {
+		t.Error(err)
+	}
+
+	msg.JSONValues["tags"] = []string{"trace"}
+	rfc3164 := msg.String()
+
+	if want, got := true, strings.Contains(rfc3164, "tags"); want != got {
+		t.Errorf("want '%v', got '%v'", want, got)
+	}
+
+	if want, got := true, strings.Contains(rfc3164, "msg"); want != got {
+		t.Errorf("want '%v', got '%v'", want, got)
+	}
+
+}


### PR DESCRIPTION
Now, if a SyslogMsg was originally not a @cee message, but then had JSONValues added to it's k/v map, when the message is serialized back to an rfc3164 message it will be converted to an @cee message.  The original SyslogMsg.Content is assigned to the "msg" key.