### PR TITLE
Problem: JSONKeyTransfomer should use SyslogMsg.JSONValues

### DIFF
--- a/jsonkeytransformer.go
+++ b/jsonkeytransformer.go
@@ -1,7 +1,6 @@
 package captainslog
 
 import (
-	"bytes"
 	"encoding/json"
 	"strings"
 )
@@ -67,20 +66,10 @@ func (m *JSONKeyTransformer) Transform(msg SyslogMsg) (SyslogMsg, error) {
 		return msg, ErrTransform
 	}
 
-	var contentStructured map[string]interface{}
-
-	decoder := json.NewDecoder(bytes.NewBuffer([]byte(msg.Content)))
-	decoder.UseNumber()
-
-	err := decoder.Decode(&contentStructured)
-	if err != nil {
-		return msg, err
-	}
-
 	transformedStructured := make(map[string]interface{})
-	m.recurseTransformMap(contentStructured, transformedStructured)
-
+	m.recurseTransformMap(msg.JSONValues, transformedStructured)
 	newContent, _ := json.Marshal(transformedStructured)
 	msg.Content = string(newContent)
+	msg.JSONValues = transformedStructured
 	return msg, nil
 }

--- a/parser.go
+++ b/parser.go
@@ -1,6 +1,7 @@
 package captainslog
 
 import (
+	"bytes"
 	"encoding/json"
 	"strconv"
 	"time"
@@ -258,7 +259,9 @@ func (p *parser) parseContent() error {
 	p.tokenEnd = p.cur
 
 	if p.msg.IsCee {
-		err = json.Unmarshal(p.buf[p.tokenStart:p.tokenEnd], &p.msg.JSONValues)
+		decoder := json.NewDecoder(bytes.NewBuffer(p.buf[p.tokenStart:p.tokenEnd]))
+		decoder.UseNumber()
+		err = decoder.Decode(&p.msg.JSONValues)
 		if err != nil {
 			p.msg.IsCee = false
 		}


### PR DESCRIPTION
Solution: move code for maintaining numeric formatting to parser.go and modify JSONKeyTransformer to use the msg JSONValues map[string]interface{}.