### PR TITLE
Problem: Port in TestTCPOutputter Causing Conflicts

### DIFF
--- a/tcp_outputter_test.go
+++ b/tcp_outputter_test.go
@@ -15,7 +15,7 @@ func TestTCPOutputter(t *testing.T) {
 		t.Error(err)
 	}
 
-	address := "127.0.0.1:3333"
+	address := "127.0.0.1:33333"
 	retryInterval := 1
 
 	l, err := net.Listen("tcp", address)


### PR DESCRIPTION
This PR increments the TCP port value in `TestTCPOutputter` to decrease potential conflicts when running tests