### PR TITLE
Problem: want to tag logs with durations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,6 @@ go:
   - 1.5
 
 before_install:
-  - go get -v golang.org/x/tools/cmd/vet
-  - go get -v golang.org/x/tools/cmd/cover
   - go get -v github.com/golang/lint/golint
 
 install:
@@ -14,7 +12,6 @@ install:
   - go install -race -v ./...
 
 script:
-  - go vet ./...
   - $HOME/gopath/bin/golint .
   - go test -cpu=2 -race -v ./...
   - go test -cpu=2 -covermode=atomic ./...

--- a/formatters.go
+++ b/formatters.go
@@ -2,6 +2,7 @@ package captainslog
 
 import "encoding/json"
 
+// ToJSONBytes converts the SyslogMsg to pure JSON
 func ToJSONBytes(s *SyslogMsg) []byte {
 	m := make(map[string]interface{})
 	for k, v := range s.JSONValues {

--- a/formatters.go
+++ b/formatters.go
@@ -1,0 +1,17 @@
+package captainslog
+
+import "encoding/json"
+
+func ToJSONBytes(s *SyslogMsg) []byte {
+	m := make(map[string]interface{})
+	for k, v := range s.JSONValues {
+		m[k] = v
+	}
+
+	m["syslog_host"] = s.Host
+	m["syslog_program"] = s.Tag
+	m["@timestamp"] = s.Time.String()
+	m["content"] = s.Content
+	b, _ := json.Marshal(m)
+	return b
+}

--- a/mutaterangetransformer_test.go
+++ b/mutaterangetransformer_test.go
@@ -1,9 +1,6 @@
 package captainslog
 
-import (
-	"testing"
-	"time"
-)
+import "testing"
 
 type testCase struct {
 	input  []byte
@@ -44,7 +41,7 @@ func TestMutateTransformerTTL(t *testing.T) {
 	}
 	transformer.mutex.Unlock()
 
-	time.Sleep(2 * time.Second)
+	transformer.reap()
 
 	transformer.mutex.Lock()
 	if want, got := 0, len(transformer.trackingDB); want != got {

--- a/mutators.go
+++ b/mutators.go
@@ -1,7 +1,5 @@
 package captainslog
 
-import "fmt"
-
 // TagArrayMutator is a Mutator that modifies a syslog message
 // by adding a tag value to an array of tags.
 type TagArrayMutator struct {
@@ -22,23 +20,5 @@ func NewTagArrayMutator(tagKey, tagValue string) Mutator {
 
 // Mutate modifies the SyslogMsg passed by reference.
 func (t *TagArrayMutator) Mutate(msg *SyslogMsg) error {
-	var err error
-
-	if _, ok := msg.JSONValues[t.tagKey]; !ok {
-		msg.JSONValues[t.tagKey] = make([]interface{}, 0)
-	}
-
-	switch val := msg.JSONValues[t.tagKey].(type) {
-	case []interface{}:
-		msg.JSONValues[t.tagKey] = append(val, t.tagValue)
-		if !msg.IsCee {
-			msg.IsCee = true
-			msg.Cee = " @cee:"
-			msg.JSONValues["msg"] = msg.Content[1:]
-		}
-		return err
-	default:
-		err = fmt.Errorf("tags key in message was not an array")
-		return err
-	}
+	return msg.AddTagArray(t.tagKey, t.tagValue)
 }

--- a/parser_test.go
+++ b/parser_test.go
@@ -2,6 +2,7 @@ package captainslog
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"testing"
 	"time"
@@ -704,6 +705,26 @@ func BenchmarkParserParseAndBytes(b *testing.B) {
 		}
 		if msg.Content != " hello world" {
 			panic("unexpected msg.Content")
+		}
+	}
+}
+
+func BenchmarkJSONParseNoJSON(b *testing.B) {
+	m := []byte("hello world")
+	val := make(map[string]interface{})
+	for i := 0; i < b.N; i++ {
+		err := json.Unmarshal(m, &val)
+		if err == nil {
+			panic("wat")
+		}
+	}
+}
+
+func BenchmarkJSONCheckFirstChar(b *testing.B) {
+	m := []byte("hello world")
+	for i := 0; i < b.N; i++ {
+		if bytes.Compare(m[0:0], []byte("{")) == 0 {
+			panic("wee")
 		}
 	}
 }

--- a/syslogmsg.go
+++ b/syslogmsg.go
@@ -40,6 +40,9 @@ func NewSyslogMsgFromBytes(b []byte) (SyslogMsg, error) {
 	return msg, err
 }
 
+// AddTagArray adds a tag to an array of tags at the key. If the key
+// does not already exist, it will create the key and initially it
+// to a []interface{}.
 func (s *SyslogMsg) AddTagArray(key string, value interface{}) error {
 	if _, ok := s.JSONValues[key]; !ok {
 		s.JSONValues[key] = make([]interface{}, 0)
@@ -59,6 +62,8 @@ func (s *SyslogMsg) AddTagArray(key string, value interface{}) error {
 	}
 }
 
+// AddTag adds a tag to the value at key. If the key exists,
+// the value currently at the key will be overwritten.
 func (s *SyslogMsg) AddTag(key string, value interface{}) {
 	s.JSONValues[key] = value
 }

--- a/syslogmsg.go
+++ b/syslogmsg.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"sync"
 	"time"
 )
 
@@ -18,12 +19,14 @@ type SyslogMsg struct {
 	Content    string
 	timeFormat string
 	JSONValues map[string]interface{}
+	mutex      *sync.Mutex
 }
 
 // NewSyslogMsg creates a new empty SyslogMsg.
 func NewSyslogMsg() SyslogMsg {
 	return SyslogMsg{
 		JSONValues: make(map[string]interface{}),
+		mutex:      &sync.Mutex{},
 	}
 }
 
@@ -35,6 +38,29 @@ func NewSyslogMsgFromBytes(b []byte) (SyslogMsg, error) {
 	msg := NewSyslogMsg()
 	err := Unmarshal(b, &msg)
 	return msg, err
+}
+
+func (s *SyslogMsg) AddTagArray(key string, value interface{}) error {
+	if _, ok := s.JSONValues[key]; !ok {
+		s.JSONValues[key] = make([]interface{}, 0)
+	}
+
+	switch val := s.JSONValues[key].(type) {
+	case []interface{}:
+		s.JSONValues[key] = append(val, value)
+		if !s.IsCee {
+			s.IsCee = true
+			s.Cee = " @cee:"
+			s.JSONValues["msg"] = s.Content[1:]
+		}
+		return nil
+	default:
+		return fmt.Errorf("tags key in message was not an array")
+	}
+}
+
+func (s *SyslogMsg) AddTag(key string, value interface{}) {
+	s.JSONValues[key] = value
 }
 
 // String returns the SyslogMsg as an RFC3164 string.

--- a/timesincetransformer.go
+++ b/timesincetransformer.go
@@ -5,6 +5,9 @@ import (
 	"time"
 )
 
+// TimeSinceTransformer is a transformer implementation that adds a "since" tag with
+// pointing to duration in seconds since the last time a log line that matched the
+// selectors was seen.
 type TimeSinceTransformer struct {
 	selectMatchers []Matcher
 	trackingDB     map[string]time.Time
@@ -13,7 +16,7 @@ type TimeSinceTransformer struct {
 	mutex          *sync.Mutex
 }
 
-// NewMutateRangeTransformer creates a new MutateRangeTransformer.
+// NewTimeSinceTransformer creates a new TimeSinceTransformer.
 func NewTimeSinceTransformer(waitTime time.Duration, selecters ...Matcher) *TimeSinceTransformer {
 	t := &TimeSinceTransformer{
 		selectMatchers: selecters,

--- a/timesincetransformer.go
+++ b/timesincetransformer.go
@@ -5,10 +5,11 @@ import (
 	"time"
 )
 
-// TimeSinceTransformer is a transformer implementation that adds a "since" tag with
+// TimeSinceTransformer is a transformer implementation that adds a tag with
 // pointing to duration in seconds since the last time a log line that matched the
 // selectors was seen.
 type TimeSinceTransformer struct {
+	key            string
 	selectMatchers []Matcher
 	trackingDB     map[string]time.Time
 	ttl            time.Duration
@@ -17,8 +18,9 @@ type TimeSinceTransformer struct {
 }
 
 // NewTimeSinceTransformer creates a new TimeSinceTransformer.
-func NewTimeSinceTransformer(waitTime time.Duration, selecters ...Matcher) *TimeSinceTransformer {
+func NewTimeSinceTransformer(key string, waitTime time.Duration, selecters ...Matcher) *TimeSinceTransformer {
 	t := &TimeSinceTransformer{
+		key:            key,
 		selectMatchers: selecters,
 		ttl:            waitTime * time.Second,
 		trackingDB:     make(map[string]time.Time),
@@ -70,6 +72,6 @@ func (t *TimeSinceTransformer) Transform(msg SyslogMsg) (SyslogMsg, error) {
 
 	duration := time.Since(t.trackingDB[logID])
 	t.trackingDB[logID] = time.Now()
-	msg.AddTag("since", duration.Seconds())
+	msg.AddTag(t.key, duration.Seconds())
 	return msg, err
 }

--- a/timesincetransformer.go
+++ b/timesincetransformer.go
@@ -1,0 +1,72 @@
+package captainslog
+
+import (
+	"sync"
+	"time"
+)
+
+type TimeSinceTransformer struct {
+	selectMatchers []Matcher
+	trackingDB     map[string]time.Time
+	ttl            time.Duration
+	reapInterval   time.Duration
+	mutex          *sync.Mutex
+}
+
+// NewMutateRangeTransformer creates a new MutateRangeTransformer.
+func NewTimeSinceTransformer(waitTime time.Duration, selecters ...Matcher) *TimeSinceTransformer {
+	t := &TimeSinceTransformer{
+		selectMatchers: selecters,
+		ttl:            waitTime * time.Second,
+		trackingDB:     make(map[string]time.Time),
+		reapInterval:   waitTime / 2,
+		mutex:          &sync.Mutex{},
+	}
+
+	go func() {
+		for {
+			time.Sleep(t.reapInterval)
+			t.reap()
+		}
+	}()
+
+	return t
+}
+
+// reap reaps expired keys from the trackingDB.
+func (t *TimeSinceTransformer) reap() {
+	t.mutex.Lock()
+	defer t.mutex.Unlock()
+
+	for k, v := range t.trackingDB {
+		duration := time.Since(v)
+		if duration.Seconds() > t.ttl.Seconds() {
+			delete(t.trackingDB, k)
+		}
+	}
+}
+
+// Transform accepts a SyslogMsg and applies the Transformer to it.
+func (t *TimeSinceTransformer) Transform(msg SyslogMsg) (SyslogMsg, error) {
+	var err error
+
+	for _, m := range t.selectMatchers {
+		if !m.Match(&msg) {
+			return msg, nil
+		}
+	}
+
+	t.mutex.Lock()
+	defer t.mutex.Unlock()
+
+	logID := getMsgID(&msg)
+
+	if _, ok := t.trackingDB[logID]; !ok {
+		t.trackingDB[logID] = time.Now()
+	}
+
+	duration := time.Since(t.trackingDB[logID])
+	t.trackingDB[logID] = time.Now()
+	msg.AddTag("since", duration.Seconds())
+	return msg, err
+}

--- a/timesincetransformer_test.go
+++ b/timesincetransformer_test.go
@@ -1,0 +1,36 @@
+package captainslog
+
+import "testing"
+
+func TestTimeSinceTransformerTransform(t *testing.T) {
+	cases := []testCase{
+		testCase{
+			input:  []byte("<182>2016-04-07T19:31:49.643625+00:00 test.example.com rsyslogd-pstats: @cee:{\"inblock\":0,\"majflt\":0,\"maxrss\":5020,\"minflt\":624,\"name\":\"resource-usage\",\"nivcsw\":14,\"nvcsw\":1358,\"origin\":\"impstats\",\"oublock\":136,\"stime\":59937,\"utime\":174816}\n"),
+			result: true,
+		},
+	}
+
+	transformer := NewTimeSinceTransformer(
+		86400,
+		NewContentContainsMatcher("inblock"),
+	)
+
+	for i, v := range cases {
+		original := NewSyslogMsg()
+		err := Unmarshal(v.input, &original)
+		if err != nil {
+			t.Error(err)
+		}
+
+		mutated, err := transformer.Transform(original)
+		if err != nil {
+			t.Error(err)
+		}
+
+		_, hasTagsKey := mutated.JSONValues["since"]
+
+		if want, got := v.result, hasTagsKey; want != got {
+			t.Errorf("case %d: want '%v', got '%v'", i, want, got)
+		}
+	}
+}

--- a/timesincetransformer_test.go
+++ b/timesincetransformer_test.go
@@ -11,7 +11,7 @@ func TestTimeSinceTransformerTransform(t *testing.T) {
 	}
 
 	transformer := NewTimeSinceTransformer(
-		86400,
+		"since", 86400,
 		NewContentContainsMatcher("inblock"),
 	)
 


### PR DESCRIPTION
To solve a problem we needed the ability to tag logs with a duration since the last time a log that matched characteristics of that log line was seen.  The PR adds TimeSinceTransformer, a transformer which serves this purpose.