### PR TITLE
Problem: need to prefix match on program tag

### DIFF
--- a/matchers.go
+++ b/matchers.go
@@ -10,10 +10,7 @@ type TagMatcher struct {
 // Match applies the match to a SyslogMsg. It returns
 // true of the tag matches and false if not.
 func (t *TagMatcher) Match(msg *SyslogMsg) bool {
-	if msg.Tag == t.match {
-		return true
-	}
-	return false
+	return strings.HasPrefix(msg.Tag, t.match)
 }
 
 // NewTagMatcher creates a TagMatcher that tries

--- a/matchers_test.go
+++ b/matchers_test.go
@@ -19,6 +19,10 @@ func TestTagMatcher(t *testing.T) {
 		t.Errorf("want %t, got %t", want, got)
 	}
 
+	prefixMatcher := NewTagMatcher("tes")
+	if want, got := true, prefixMatcher.Match(&msg); want != got {
+		t.Errorf("want %t, got %t", want, got)
+	}
 }
 
 func TestContentContainsMatcher(t *testing.T) {
@@ -37,5 +41,4 @@ func TestContentContainsMatcher(t *testing.T) {
 	if want, got := false, badMatcher.Match(&msg); want != got {
 		t.Errorf("want %t, got %t", want, got)
 	}
-
 }


### PR DESCRIPTION
Since we do not currently distinguish between "program name" and "tag" when parsing, and since some programs include '[pid]' as part of the syslog tag, we need the TagMatcher to do a prefix match instead of an exact match until this is handled in SyslogMsg.