### PR TITLE
Problem: NewSyslogMsgFromBytes should handle end of slice as end of c…

### DIFF
--- a/parser_test.go
+++ b/parser_test.go
@@ -587,9 +587,10 @@ func TestUnmarshalNoTag(t *testing.T) {
 func TestUnmarshalContentNotTerminated(t *testing.T) {
 	b := []byte("<191>2006-01-02T15:04:05.999999-07:00 host.example.org test: hello wo")
 	_, err := NewSyslogMsgFromBytes(b)
-
-	if want, got := ErrBadContent, err; want != got {
-		t.Errorf("want '%s', got '%s'", want, got)
+	// 2016-07-22: changed this test to pass as default NewSyslogMsgFromBytes now
+	// treats end buffer as end of content.
+	if err != nil {
+		t.Error(err)
 	}
 }
 

--- a/syslogmsg.go
+++ b/syslogmsg.go
@@ -8,6 +8,24 @@ import (
 	"time"
 )
 
+// Unmarshal accepts a byte array containing an rfc3164 message
+// and a pointer to a SyslogMsg struct, and attempts to parse
+// the message and fill in the struct.
+func Unmarshal(b []byte, msg *SyslogMsg) error {
+
+	p := &parser{
+		buf:               b,
+		bufLen:            len(b),
+		bufEnd:            len(b) - 1,
+		cur:               0,
+		requireTerminator: false,
+		msg:               msg,
+	}
+
+	err := p.parse()
+	return err
+}
+
 // SyslogMsg holds an Unmarshaled rfc3164 message.
 type SyslogMsg struct {
 	Pri        Priority


### PR DESCRIPTION
* Added boolean  option to parser to configure whether content section of rfc3164 message should require a '\n' terminator or if end of []byte slice can be treated as end of message
* Changed NewSyslogMsgFromBytes to set this option so that []byte message will be treated as full syslog message and not require a '\n' terminator.