### PR TITLE
Problem: sometimes dont want to parse json

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-  - 1.5
+  - 1.7
 
 before_install:
   - go get -v github.com/golang/lint/golint

--- a/priority.go
+++ b/priority.go
@@ -43,29 +43,29 @@ const (
 )
 
 func (s Severity) String() string {
-	var severity_text string
+	var severityText string
 
 	switch s {
 	case Emerg:
-		severity_text = "emerg"
+		severityText = "emerg"
 	case Alert:
-		severity_text = "alert"
+		severityText = "alert"
 	case Crit:
-		severity_text = "crit"
+		severityText = "crit"
 	case Err:
-		severity_text = "err"
+		severityText = "err"
 	case Warning:
-		severity_text = "warning"
+		severityText = "warning"
 	case Notice:
-		severity_text = "notice"
+		severityText = "notice"
 	case Info:
-		severity_text = "info"
+		severityText = "info"
 	case Debug:
-		severity_text = "debug"
+		severityText = "debug"
 	default:
 	}
 
-	return severity_text
+	return severityText
 }
 
 // Facility represents a syslog facility code
@@ -134,53 +134,53 @@ const (
 )
 
 func (f Facility) String() string {
-	var facility_text string
+	var faciliyText string
 
 	switch f {
 	case Kern:
-		facility_text = "kern"
+		faciliyText = "kern"
 	case User:
-		facility_text = "user"
+		faciliyText = "user"
 	case Mail:
-		facility_text = "mail"
+		faciliyText = "mail"
 	case Daemon:
-		facility_text = "daemon"
+		faciliyText = "daemon"
 	case Auth:
-		facility_text = "auth"
+		faciliyText = "auth"
 	case Syslog:
-		facility_text = "syslog"
+		faciliyText = "syslog"
 	case LPR:
-		facility_text = "lpr"
+		faciliyText = "lpr"
 	case News:
-		facility_text = "news"
+		faciliyText = "news"
 	case UUCP:
-		facility_text = "uucp"
+		faciliyText = "uucp"
 	case Cron:
-		facility_text = "cron"
+		faciliyText = "cron"
 	case AuthPriv:
-		facility_text = "authpriv"
+		faciliyText = "authpriv"
 	case FTP:
-		facility_text = "ftp"
+		faciliyText = "ftp"
 	case Local0:
-		facility_text = "local0"
+		faciliyText = "local0"
 	case Local1:
-		facility_text = "local1"
+		faciliyText = "local1"
 	case Local2:
-		facility_text = "local2"
+		faciliyText = "local2"
 	case Local3:
-		facility_text = "local3"
+		faciliyText = "local3"
 	case Local4:
-		facility_text = "local4"
+		faciliyText = "local4"
 	case Local5:
-		facility_text = "local5"
+		faciliyText = "local5"
 	case Local6:
-		facility_text = "local6"
+		faciliyText = "local6"
 	case Local7:
-		facility_text = "local7"
+		faciliyText = "local7"
 	default:
 	}
 
-	return facility_text
+	return faciliyText
 }
 
 // Priority represents the PRI of a rfc3164 message.

--- a/syslogmsg_test.go
+++ b/syslogmsg_test.go
@@ -61,3 +61,21 @@ func TestSyslogMsgJSONFromCEE(t *testing.T) {
 		t.Errorf("want %q, got %q", want, got)
 	}
 }
+
+func TestSyslogMsgJSONFromCEEWithDontParseJSON(t *testing.T) {
+	input := []byte("<4>2016-03-08T14:59:36.293816+00:00 host.example.com kernel: @cee:{\"a\":1}\n")
+	msg, err := NewSyslogMsgFromBytes(input, OptionDontParseJSON)
+	if err != nil {
+		t.Error(err)
+	}
+
+	output, err := msg.JSON()
+	if err != nil {
+		t.Error(err)
+	}
+
+	wanted := `{"a":1,"syslog_facilitytext":"kern","syslog_host":"host.example.com","syslog_program":"kernel:","syslog_severitytext":"warning","syslog_time":"2016-03-08T14:59:36.293816Z"}`
+	if want, got := wanted, string(output); want != got {
+		t.Errorf("want %q, got %q", want, got)
+	}
+}


### PR DESCRIPTION
Sometimes we want to parse "cee" rfc3164 messages without parsing the JSON in the message body. If we just want access to syslog headers, not parsing the JSON saves quite a bit of time. This PR adds an optional function argument ( "OptionDontParseJSON" ) that may be passed to the NewParser and NewSyslogMsg constructors to tell the parser to save "cee" message content without actually parsing it.

If JSON values are added to the message after the original parse, and SyslogMsg.String(), SyslogMsg.Bytes(), or SyslogMsg.JSON() are called, the message content will be parsed at that time in order to combine the fields within it with any fields added to SyslogMsg.JSONValues. Otherwise, SyslogMsg.Content will be used without ever incurring the penalty of a JSON parse.

This PR also fixes some minor golint / go vet issues.