### PR TITLE
Problem: go truncates time resolution when ending in 0s

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -37,6 +37,19 @@ var (
 		"Mon Jan _2 15:04:05",
 		"Jan _2 15:04:05",
 		"Jan 02 15:04:05",
+
+		// these are here because go's time.Format call truncates 0s when converting
+		// to a string, even if the format specifies a longer string. eg,
+		// .999990 will become .99999. they are at the end of the list because
+		// timetamps like this when dealing with syslog traffic should
+		// be rare to non existent when dealing with logs from anything other
+		// than go code.
+
+		"2006-01-02T15:04:05.99999-07:00",
+		"2006-01-02T15:04:05.9999-07:00",
+		"2006-01-02T15:04:05.999-07:00",
+		"2006-01-02T15:04:05.99-07:00",
+		"2006-01-02T15:04:05.9-07:00",
 	}
 )
 

--- a/parser_test.go
+++ b/parser_test.go
@@ -501,6 +501,14 @@ func TestUnmarshalTagEndHandling(t *testing.T) {
 	}
 }
 
+func TestHandlingTruncatedSubseconds(t *testing.T) {
+	b := []byte("<191>2006-01-02T15:04:05.99999-07:00 host.example.org test: hello world\n")
+	_, err := NewSyslogMsgFromBytes(b)
+	if err != nil {
+		t.Error(err)
+	}
+}
+
 func TestUnmarshalUnixTime(t *testing.T) {
 	b := []byte("<38>Mon Jan  2 15:04:05 host.example.org test: hello world\n")
 	msg, err := NewSyslogMsgFromBytes(b)


### PR DESCRIPTION
When using a time format such as "2006-01-02T15:04:05.999999-07:00", in cases where a time's subseconds end in one or more 0s, time.Format(<format>) will truncate the length of the string.

This does not play well with code in the parser  that uses the length of time formats to find time strings within a syslog message: https://github.com/digitalocean/captainslog/blob/master/parser.go#L186-L201

This solution to the problem is not idea, but has the benefit of being simple, and in cases where the parser is dealing with syslog messages with standard time formats, does not add overhead.

Reference: https://github.com/digitalocean/captainslog/issues/50