### PR TITLE
Problem: time parsing code was slow for non best cases

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -10,9 +10,10 @@ import (
 )
 
 const (
-	priStart = '<'
-	priEnd   = '>'
-	priLen   = 5
+	priStart     = '<'
+	priEnd       = '>'
+	priLen       = 5
+	dateStampLen = 10
 )
 
 var (
@@ -28,28 +29,15 @@ var (
 	//ErrBadContent is returned when the content of a message is malformed.
 	ErrBadContent = errors.New("Content not found")
 
+	dateStampFormat   = "2006-01-02"
+	rsyslogTimeFormat = "2006-01-02T15:04:05.999999-07:00"
+
 	timeFormats = []string{
-		"2006-01-02T15:04:05.999999-07:00",
-		"2006-01-02T15:04:05.999-07:00",
-		"2006-01-02T15:04:05-07:00",
 		"Mon Jan _2 15:04:05 MST 2006",
 		"Mon Jan _2 15:04:05 2006",
 		"Mon Jan _2 15:04:05",
 		"Jan _2 15:04:05",
 		"Jan 02 15:04:05",
-
-		// these are here because go's time.Format call truncates 0s when converting
-		// to a string, even if the format specifies a longer string. eg,
-		// .999990 will become .99999. they are at the end of the list because
-		// timetamps like this when dealing with syslog traffic should
-		// be rare to non existent when dealing with logs from anything other
-		// than go code.
-
-		"2006-01-02T15:04:05.99999-07:00",
-		"2006-01-02T15:04:05.9999-07:00",
-		"2006-01-02T15:04:05.999-07:00",
-		"2006-01-02T15:04:05.99-07:00",
-		"2006-01-02T15:04:05.9-07:00",
 	}
 )
 
@@ -191,11 +179,51 @@ func (p *Parser) parsePri() error {
 	return err
 }
 
+// checkForDateTime checks for a YYYY-MM-DD date. This routine could be modified
+// to be more efficient, as constructing a time.Time is not necessary. For now
+// this is a simple way to avoid the complexity of checking for a valid
+// datetime, which is more complicated than it might first appear to be.
+func checkForDateTime(timeStr string) bool {
+	_, err := time.Parse(dateStampFormat, timeStr)
+	if err != nil {
+		return false
+	}
+	return true
+}
+
 func (p *Parser) parseTime() error {
 	var err error
 	var foundTime bool
 
 	p.tokenStart = p.cur
+
+	// no timestamp format is shorter than YYYY-MM-DD, so if buffer is shorter
+	// than this it is safe to assume we don't have a valid datetime.
+	if p.cur+dateStampLen > p.bufEnd {
+		return ErrBadTime
+	}
+
+	if checkForDateTime(string(p.buf[p.cur : p.cur+dateStampLen])) {
+		tokenStart := p.cur
+		tokenEnd := p.cur
+
+		for p.buf[tokenEnd] != ' ' {
+			tokenEnd++
+			if tokenEnd > p.bufEnd {
+				return ErrBadTime
+			}
+		}
+
+		timeStr := string(p.buf[tokenStart:tokenEnd])
+		p.msg.Time, err = time.Parse(rsyslogTimeFormat, timeStr)
+		if err == nil {
+			p.cur = tokenEnd
+			p.tokenEnd = p.cur
+			p.msg.timeFormat = rsyslogTimeFormat
+		}
+		return err
+	}
+
 	for _, timeFormat := range timeFormats {
 		tLen := len(timeFormat)
 		if p.cur+tLen > p.bufEnd {

--- a/workdir/corpus/truncatedsubseconds.txt
+++ b/workdir/corpus/truncatedsubseconds.txt
@@ -1,0 +1,2 @@
+<191>2006-01-02T15:04:05.9999-07:00 host.example.org test: hello world
+


### PR DESCRIPTION
Solution: add some logic for fast determination of rfc3339 style timestamps and a separate code path for handling them.