### PR TITLE
Problem: want to support logging to local syslog

### DIFF
--- a/syslogmsg.go
+++ b/syslogmsg.go
@@ -213,7 +213,7 @@ func (s *SyslogMsg) String(options ...SyslogMsgOption) string {
 	}
 
 	if s.optionUseLocalFormat {
-		return fmt.Sprintf("<%s>%s %s%s%s\n", s.Pri.String(), s.Time.Format("Jan 02 15:04:05"), s.Tag.String(), s.Cee, content)
+		return fmt.Sprintf("<%s>%s %s%s%s\n", s.Pri.String(), s.Time.Format(time.Stamp), s.Tag.String(), s.Cee, content)
 	} else {
 		if s.timeFormat == "" {
 			s.timeFormat = rsyslogTimeFormat

--- a/syslogmsg.go
+++ b/syslogmsg.go
@@ -218,7 +218,7 @@ func (s *SyslogMsg) String(options ...SyslogMsgOption) string {
 		if s.timeFormat == "" {
 			s.timeFormat = rsyslogTimeFormat
 		}
-		return fmt.Sprintf("<%s>%s %s %s%s%s\n", s.Pri, s.Time.Format(s.timeFormat), s.Host, s.Tag.String(), s.Cee, content)
+		return fmt.Sprintf("<%s>%s %s %s%s%s\n", s.Pri.String(), s.Time.Format(s.timeFormat), s.Host, s.Tag.String(), s.Cee, content)
 	}
 }
 


### PR DESCRIPTION
Rsyslog, listening on a local unix socket, expects a different logging format that what it receives on the wire (TCP/UDP). This PR adds formatting options for SyslogMsg.String() / SyslogMsg.Bytes() to support local logging format.