### PR TITLE
Problem: Building a SyslogMsg with SetContent does not set IsJSON flag if the message is JSON

### DIFF
--- a/syslogmsg.go
+++ b/syslogmsg.go
@@ -145,6 +145,9 @@ func (s *SyslogMsg) SetContent(c string) error {
 	_, content, err := ParseContent([]byte(c), ContentOptionParseJSON)
 	s.Content = content.Content
 	s.JSONValues = content.JSONValues
+	if len(s.JSONValues) > 0 {
+		s.IsJSON = true
+	}
 	return err
 }
 

--- a/syslogmsg_test.go
+++ b/syslogmsg_test.go
@@ -40,7 +40,6 @@ func TestSyslogMsgPlainWithAddedKeys(t *testing.T) {
 	if want, got := true, strings.Contains(rfc3164, "msg"); want != got {
 		t.Errorf("want '%v', got '%v'", want, got)
 	}
-
 }
 
 func TestSyslogMsgJSONFromPlain(t *testing.T) {


### PR DESCRIPTION
This causes the `msg` field to be populated with the string representation of the Content, which may be JSON. If that Content contains a field labeled `msg`, it will be overwritten by the JSON string.