### PR TITLE
Add Optional Faster Third Party JSON Parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ captainslog.NewSyslogMsg accepts the following functional options (note: these m
 **captainslog.OptionUseLocalFormat** tells SyslogMsg.String() and SyslogMsg.Byte() to format the message to be compatible with writing to /dev/log rather than over the wire.
 
 **captainslog.OptionUseRemoteFormat** tells SyslogMsg.String() and SyslogMsg.Byte() to use wire format for the message instead of local format.
+
 ## Serialize a captainslog.SyslogMsg to RFC3164 bytes:
 ```go
 b := msg.Bytes()
@@ -45,6 +46,8 @@ Both captainslog.NewSyslogMsgFromBytes and captainslog.NewParser accept the foll
 **captainslog.OptionNoHostname** sets the parser to not expect the hostname as part of the syslog message, and instead ask the host for its hostname.
 
 **captainslog.OptionDontParseJSON** sets the parser to not parse JSON in the content field of the message. A subsequent call to SyslogMsg.String() or SyslogMsg.Bytes() will then use SyslogMsg.Content for the content field, unless SyslogMsg.JSONValues have been added since the message was originally parsed. If SyslogMsg.JSONValues have been added, the call to SyslogMsg.String() or SyslogMsg.Bytes() will then parse the JSON, and merge the results with the keys in SyslogMsg.JSONVaues.
+
+**captainslog.OptionUseGJSONParser** uses the [tidwall/gjson](https://github.com/tidwall/gjson) parser to parse JSON in the content field of the message.  This may improve parsing performance.
 
 **captainslog.OptionLocation** is a helper function to configure the parser to parse time in the given timezone, If the parsed time contains a valid timezone identifier this takes precedence. Default timezone is UTC.
 ## Contibution Guidelines

--- a/parser_test.go
+++ b/parser_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/jnadler/captainslog"
+	"github.com/digitalocean/captainslog"
 )
 
 func TestParser(t *testing.T) {

--- a/parser_test.go
+++ b/parser_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/digitalocean/captainslog"
+	"github.com/jnadler/captainslog"
 )
 
 func TestParser(t *testing.T) {
@@ -661,6 +661,30 @@ func TestParser(t *testing.T) {
 			content:  " hello world",
 			jsonKeys: []string{},
 		},
+		{
+			name:     "parse CEE using optional GJSON parser",
+			input:    "<191>2006-01-02T15:04:05.999999-07:00 host.example.org test[241]: @cee:{\"egid\":0,\"eid\":0,\"env\":\"production\",\"host\":\"myhost.example.org\",\"level\":\"info\",\"msg\":\"request complete\",\"pid\":7,\"pname\":\"/bin/myprogram\",\"req_method\":\"GET\",\"req_path\":\"/bin/myprogram/\",\"req_remote_ip\":\"172.0.0.1\",\"req_useragent\":\"my-client;go=go1.11.1\",\"resp_bytes_per_sec\":40562776957,\"resp_code\":200,\"resp_duration\":\"1.345193477s\",\"resp_duration_ms\":1345.193477,\"resp_latency\":\"1.345069502s\",\"resp_latency_ms\":1345.069502,\"resp_mebibytes_per_sec\":38683.678586006165,\"resp_size\":54922,\"system\":\"server\",\"time\":\"2019-03-04T19:21:26.895323594Z\",\"version\":\"5b82fdcddaf0286e7fec3a5f8dbf7a67a325fd6b\"}\n",
+			options:  []func(*captainslog.Parser){captainslog.OptionLocation(time.FixedZone("UTC-8", -8*60*60)), captainslog.OptionUseGJSONParser},
+			err:      nil,
+			facility: captainslog.Local7,
+			severity: captainslog.Debug,
+			year:     2006,
+			month:    1,
+			day:      2,
+			hour:     15,
+			minute:   4,
+			second:   5,
+			millis:   999999,
+			offset:   -7 * 60 * 60,
+			host:     "host.example.org",
+			program:  "test",
+			tag:      "test[241]:",
+			pid:      "241",
+			cee:      true,
+			json:     true,
+			content:  "{\"egid\":0,\"eid\":0,\"env\":\"production\",\"host\":\"myhost.example.org\",\"level\":\"info\",\"msg\":\"request complete\",\"pid\":7,\"pname\":\"/bin/myprogram\",\"req_method\":\"GET\",\"req_path\":\"/bin/myprogram/\",\"req_remote_ip\":\"172.0.0.1\",\"req_useragent\":\"my-client;go=go1.11.1\",\"resp_bytes_per_sec\":40562776957,\"resp_code\":200,\"resp_duration\":\"1.345193477s\",\"resp_duration_ms\":1345.193477,\"resp_latency\":\"1.345069502s\",\"resp_latency_ms\":1345.069502,\"resp_mebibytes_per_sec\":38683.678586006165,\"resp_size\":54922,\"system\":\"server\",\"time\":\"2019-03-04T19:21:26.895323594Z\",\"version\":\"5b82fdcddaf0286e7fec3a5f8dbf7a67a325fd6b\"}",
+			jsonKeys: []string{"egid", "eid", "env", "host", "level", "msg", "pid", "pname", "req_method", "req_path", "req_remote_ip", "req_useragent", "resp_bytes_per_sec", "resp_code", "resp_duration", "resp_duration_ms", "resp_latency", "resp_latency_ms", "resp_mebibytes_per_sec", "resp_size", "system", "time", "version"},
+		},
 	}
 
 	for _, tc := range testCases {
@@ -836,6 +860,42 @@ func BenchmarkParserParseCEE(b *testing.B) {
 		}
 		if msg.Host != "host.example.org" {
 			panic("unexpected msg.Host")
+		}
+	}
+}
+
+func BenchmarkParserParseLongCEE(b *testing.B) {
+	m := []byte("<191>2006-01-02T15:04:05.999999-07:00 host.example.org test: @cee:{\"egid\":0,\"eid\":0,\"env\":\"production\",\"host\":\"myhost.example.org\",\"level\":\"info\",\"msg\":\"request complete\",\"pid\":7,\"pname\":\"/bin/myprogram\",\"req_method\":\"GET\",\"req_path\":\"/bin/myprogram/\",\"req_remote_ip\":\"172.0.0.1\",\"req_useragent\":\"my-client;go=go1.11.1\",\"resp_bytes_per_sec\":40562776957,\"resp_code\":200,\"resp_duration\":\"1.345193477s\",\"resp_duration_ms\":1345.193477,\"resp_latency\":\"1.345069502s\",\"resp_latency_ms\":1345.069502,\"resp_mebibytes_per_sec\":38683.678586006165,\"resp_size\":54922,\"system\":\"server\",\"time\":\"2019-03-04T19:21:26.895323594Z\",\"version\":\"5b82fdcddaf0286e7fec3a5f8dbf7a67a325fd6b\"}\n")
+
+	for i := 0; i < b.N; i++ {
+		b.SetBytes(int64(len(m)))
+		msg, err := captainslog.NewSyslogMsgFromBytes(m)
+		if err != nil {
+			panic(err)
+		}
+		if msg.Host != "host.example.org" {
+			panic("unexpected msg.Host")
+		}
+		if msg.JSONValues["host"] != "myhost.example.org" {
+			panic("unexpected JSON value host")
+		}
+	}
+}
+
+func BenchmarkParserParseLongCEEWithGJSON(b *testing.B) {
+	m := []byte("<191>2006-01-02T15:04:05.999999-07:00 host.example.org test: @cee:{\"egid\":0,\"eid\":0,\"env\":\"production\",\"host\":\"myhost.example.org\",\"level\":\"info\",\"msg\":\"request complete\",\"pid\":7,\"pname\":\"/bin/myprogram\",\"req_method\":\"GET\",\"req_path\":\"/bin/myprogram/\",\"req_remote_ip\":\"172.0.0.1\",\"req_useragent\":\"my-client;go=go1.11.1\",\"resp_bytes_per_sec\":40562776957,\"resp_code\":200,\"resp_duration\":\"1.345193477s\",\"resp_duration_ms\":1345.193477,\"resp_latency\":\"1.345069502s\",\"resp_latency_ms\":1345.069502,\"resp_mebibytes_per_sec\":38683.678586006165,\"resp_size\":54922,\"system\":\"server\",\"time\":\"2019-03-04T19:21:26.895323594Z\",\"version\":\"5b82fdcddaf0286e7fec3a5f8dbf7a67a325fd6b\"}\n")
+
+	for i := 0; i < b.N; i++ {
+		b.SetBytes(int64(len(m)))
+		msg, err := captainslog.NewSyslogMsgFromBytes(m, captainslog.OptionUseGJSONParser)
+		if err != nil {
+			panic(err)
+		}
+		if msg.Host != "host.example.org" {
+			panic("unexpected msg.Host")
+		}
+		if msg.JSONValues["host"] != "myhost.example.org" {
+			panic("unexpected JSON value host")
 		}
 	}
 }


### PR DESCRIPTION
Use the [tidwall/gjson](https://github.com/tidwall/gjson) JSON parser optionally.   Default behavior is unchanged.

For benchmarks with long lists of JSON fields this runs approx 3x faster.