### PR TITLE
problem: no test for tags over 32 chars

### DIFF
--- a/parser_test.go
+++ b/parser_test.go
@@ -719,6 +719,32 @@ func TestParser(t *testing.T) {
 			content:  "{\"egid\":0,\"eid\":0,\"env\":\"production\",\"host\":\"myhost.example.org\",\"level\":\"info\",\"msg\":\"request complete\",\"pid\":7,\"pname\":\"/bin/myprogram\",\"req_method\":\"GET\",\"req_path\":\"/bin/myprogram/\",\"req_remote_ip\":\"172.0.0.1\",\"req_useragent\":\"my-client;go=go1.11.1\",\"resp_bytes_per_sec\":40562776957,\"resp_code\":200,\"resp_duration\":\"1.345193477s\",\"resp_duration_ms\":1345.193477,\"resp_latency\":\"1.345069502s\",\"resp_latency_ms\":1345.069502,\"resp_mebibytes_per_sec\":38683.678586006165,\"resp_size\":54922,\"system\":\"server\",\"time\":\"2019-03-04T19:21:26.895323594Z\",\"version\":\"5b82fdcddaf0286e7fec3a5f8dbf7a67a325fd6b\"}",
 			jsonKeys: []string{"egid", "eid", "env", "host", "level", "msg", "pid", "pname", "req_method", "req_path", "req_remote_ip", "req_useragent", "resp_bytes_per_sec", "resp_code", "resp_duration", "resp_duration_ms", "resp_latency", "resp_latency_ms", "resp_mebibytes_per_sec", "resp_size", "system", "time", "version"},
 		},
+		{
+			name:     "parse with syslog tag over 32 chars",
+			input:    "<191>2006-01-02T15:04:05.999999-07:00 host.example.org abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz hello world\n",
+			options:  []func(*captainslog.Parser){},
+			err:      nil,
+			facility: captainslog.Local7,
+			severity: captainslog.Debug,
+			year:     2006,
+			month:    1,
+			day:      2,
+			hour:     15,
+			minute:   4,
+			second:   5,
+			millis:   999999,
+			offset:   -25200,
+			host:     "host.example.org",
+			program:  "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz",
+			tag:  "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz",
+			pid:      "",
+			cee:      false,
+			json:     false,
+			content:  " hello world",
+			jsonKeys: []string{},
+		},
+
+
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
Rsyslog, when parsing syslog messages with tags longer than 32 characters, truncates the TAG field to 32 characters. Captainslog does not have a maximum length on TAG size other than the max length of the message. This behavior should probably be changed to be in line with how rsyslog does things.

For now, this PR adds a test that documents the current behavior to make it more explicit.